### PR TITLE
fix: ブラウザモードでAPIキーの保存・管理ができない問題を修正

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -154,24 +154,70 @@ const api = {
 
   get_config() {
     const configPath = path.join(CONFIG_DIR, 'config.json');
-    if (!fs.existsSync(configPath)) {
-      return {
-        theme: 'dark',
-        features: { ai_copilot: false, diff_highlight: true },
-        font_size: 14,
-        vim_mode: false,
-        openrouter_api_key: null,
-      };
+    let config = {
+      theme: 'dark',
+      features: { ai_copilot: false, diff_highlight: true },
+      font_size: 14,
+      vim_mode: false,
+    };
+    if (fs.existsSync(configPath)) {
+      try {
+        config = { ...config, ...JSON.parse(fs.readFileSync(configPath, 'utf-8')) };
+      } catch { /* ignore */ }
     }
-    return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const hasApiKey = !!(config.openrouter_api_key);
+    // Return ConfigResponse format (matching Tauri backend)
+    return {
+      theme: config.theme,
+      features: config.features,
+      font_size: config.font_size,
+      vim_mode: config.vim_mode,
+      has_api_key: hasApiKey,
+      api_key_storage: 'config',
+      ai_model: config.ai_model || null,
+      sidebar_sort: config.sidebar_sort || 'name_asc',
+      sidebar_show_all_files: config.sidebar_show_all_files || false,
+    };
   },
 
   save_config({ config }) {
-    fs.writeFileSync(
-      path.join(CONFIG_DIR, 'config.json'),
-      JSON.stringify(config, null, 2),
-      'utf-8',
-    );
+    const configPath = path.join(CONFIG_DIR, 'config.json');
+    // Preserve API key from existing config (it's managed separately via set_api_key)
+    let existing = {};
+    try {
+      existing = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch { /* ignore */ }
+    const toSave = { ...config };
+    // Keep existing API key if not explicitly provided
+    if (!toSave.openrouter_api_key && existing.openrouter_api_key) {
+      toSave.openrouter_api_key = existing.openrouter_api_key;
+    }
+    // Remove ConfigResponse-only fields that shouldn't be persisted
+    delete toSave.has_api_key;
+    delete toSave.api_key_storage;
+    fs.writeFileSync(configPath, JSON.stringify(toSave, null, 2), 'utf-8');
+    return null;
+  },
+
+  set_api_key({ key }) {
+    const configPath = path.join(CONFIG_DIR, 'config.json');
+    let config = {};
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch { /* ignore */ }
+    config.openrouter_api_key = key;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+    return 'config';
+  },
+
+  delete_api_key() {
+    const configPath = path.join(CONFIG_DIR, 'config.json');
+    let config = {};
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch { /* ignore */ }
+    delete config.openrouter_api_key;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
     return null;
   },
 

--- a/src/js/__tests__/backend.test.js
+++ b/src/js/__tests__/backend.test.js
@@ -98,6 +98,18 @@ describe('backend module (Tauri mode)', () => {
     expect(mockInvoke).toHaveBeenCalledWith('save_config', { config });
   });
 
+  it('setApiKey calls invoke with set_api_key command', async () => {
+    const mod = await import('../backend.js');
+    await mod.setApiKey('sk-test-123');
+    expect(mockInvoke).toHaveBeenCalledWith('set_api_key', { key: 'sk-test-123' });
+  });
+
+  it('deleteApiKey calls invoke with delete_api_key command', async () => {
+    const mod = await import('../backend.js');
+    await mod.deleteApiKey();
+    expect(mockInvoke).toHaveBeenCalledWith('delete_api_key');
+  });
+
   it('getOpenDir calls invoke with get_open_dir command', async () => {
     const mod = await import('../backend.js');
     await mod.getOpenDir();
@@ -130,6 +142,8 @@ describe('backend module (Tauri mode)', () => {
       ['loadSession', 'load_session'],
       ['getConfig', 'get_config'],
       ['saveConfig', 'save_config'],
+      ['setApiKey', 'set_api_key'],
+      ['deleteApiKey', 'delete_api_key'],
       ['getOpenDir', 'get_open_dir'],
       ['browseDir', 'browse_dir'],
     ];

--- a/src/js/__tests__/settings.test.js
+++ b/src/js/__tests__/settings.test.js
@@ -96,4 +96,39 @@ describe('settings module', () => {
     expect(hint).not.toBeNull();
     expect(hint.textContent).toContain('OS Keychain');
   });
+
+  it('save calls setApiKey when API key is provided', async () => {
+    const backend = await import('../backend.js');
+    await mod.openSettings();
+
+    const input = document.querySelector('#setting-api-key');
+    // Simulate user typing a key
+    Object.defineProperty(input, 'value', { value: 'sk-or-test-key', writable: true });
+
+    const saveBtn = document.querySelector('.btn-save-settings');
+    saveBtn.click();
+    // Wait for async save
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(backend.setApiKey).toHaveBeenCalledWith('sk-or-test-key');
+    expect(backend.saveConfig).toHaveBeenCalled();
+    // API key should not be in the config passed to saveConfig
+    const savedConfig = backend.saveConfig.mock.calls[0][0];
+    expect(savedConfig.openrouter_api_key).toBeNull();
+  });
+
+  it('save does not call setApiKey when API key is empty', async () => {
+    const backend = await import('../backend.js');
+    backend.setApiKey.mockClear();
+    backend.saveConfig.mockClear();
+    mod.closeSettings();
+    await mod.openSettings();
+
+    const saveBtn = document.querySelector('.btn-save-settings');
+    saveBtn.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(backend.setApiKey).not.toHaveBeenCalled();
+    expect(backend.saveConfig).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- ブラウザモード（serve.js）に `set_api_key` / `delete_api_key` エンドポイントを追加
- `get_config` を ConfigResponse 形式に統一し `has_api_key` / `api_key_storage` を返すように修正
- `save_config` で APIキーが意図せず消える問題を対処
- backend.test.js / settings.test.js に APIキー関連テストを追加（87→91テスト）

## Test plan
- [x] `npx vitest run` 全91テストパス
- [ ] `make browser` でブラウザモード起動 → Settings → APIキー入力 → Save → AI機能が動作することを確認
- [ ] APIキー未設定時のプレースホルダー表示を確認
- [ ] APIキー設定済み時の「Stored in: Config file」表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)